### PR TITLE
exclude ortelius-console in mono-repo helm charts for applicationset

### DIFF
--- a/kube-infra/mono-repo-applicationSet.yaml
+++ b/kube-infra/mono-repo-applicationSet.yaml
@@ -12,6 +12,8 @@ spec:
           revision: svc_cat
           directories:
           - path: chart/*
+          - path: chart/ortelius-console
+            exclude: true
       - list:
           elements:
           - cluster: production


### PR DESCRIPTION
exclude ortelius-console in mono-repo helm charts for applicationset

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>