### PR TITLE
add components in backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -53,3 +53,193 @@ spec:
   system: Platform
   lifecycle: production
 ---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: argo-rollouts 
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: argo-rollouts 
+    backstage.io/kubernetes-id: argo-rollouts 
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: argocd
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: argocd
+    backstage.io/kubernetes-id: argocd
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: backstage
+    backstage.io/kubernetes-id: backstage
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: jaeger
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: jaeger
+    backstage.io/kubernetes-id: jaeger
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: loki-stack
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: loki-stack
+    backstage.io/kubernetes-id: loki-stack
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: opentelemetry-collector
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: opentelemetry-collector
+    backstage.io/kubernetes-id: opentelemetry-collector
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ortelius-docs
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: ortelius-docs
+    backstage.io/kubernetes-id: ortelius-docs
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ortelius-www
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: ortelius-www
+    backstage.io/kubernetes-id: ortelius-www
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: podtatohead-prod
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: podtatohead-prod
+    backstage.io/kubernetes-id: podtatohead-prod
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: postgresql 
+  description: Ortelius Grafana Instance
+  annotations:
+    github.com/project-slug: ortelius/ortelius-docs
+    github.com/project-readme-path: README.md
+    argocd/app-name: postgresql 
+    backstage.io/kubernetes-id: postgresql 
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - platform
+spec:
+  type: service
+  owner: user:guest
+  system: Platform
+  lifecycle: production
+---


### PR DESCRIPTION
add components backstage 
The following components have been added:

- argo-rollouts   
- argocd            
- backstage             
- jaeger                    
- loki-stack        
- opentelemetry-collector   
- ortelius-docs        
- ortelius-www         
- podtatohead-prod        
- postgresql           

kube-prometheus-stack and ingress-nginx were already added by @bradmccoydev 