### PR TITLE
Add Techdocs page for each of the apps

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -9,3 +9,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 * @bradmccoydev
+* @itisaby

--- a/docs/backstage.md
+++ b/docs/backstage.md
@@ -1,0 +1,7 @@
+# backstage
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [backstage](https://backstage.io/) | [Project Github Link](https://github.com/backstage/backstage) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/catalog/backstage) | [Artifact Link](https://artifacthub.io/packages/helm/codecentric/backstage) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to backstage can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/cert-manager.md
+++ b/docs/cert-manager.md
@@ -1,0 +1,7 @@
+# cert-manager
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [cert-manager](https://certmanager.io) | [Project Github Link](https://github.com/cert-manager/cert-manager) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/dns-infra/cert-manager) | [Artifact Link](https://artifacthub.io/packages/helm/cert-manager/cert-manager) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to cert-manager can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/external-dns.md
+++ b/docs/external-dns.md
@@ -1,0 +1,7 @@
+# external-dns
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [external-dns](https://https://github.com/kubernetes-sigs/external-dns) | [Project Github Link](https://https://github.com/kubernetes-sigs/external-dns) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/dns-infra/external-dns-aws) | [Artifact Link](https://artifacthub.io/packages/helm/bitnami/external-dns) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to external-dns can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,7 @@
+# grafana
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [grafana](https://grafana.com/) | [Project Github Link](https://github.com/grafana/grafana) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/test/grafana) | [Artifact Link](https://artifacthub.io/packages/helm/grafana/grafana) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to grafana can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/ingress-nginx.md
+++ b/docs/ingress-nginx.md
@@ -1,0 +1,7 @@
+# Ingress-nginx
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [Ingress-nginx](https://www.nginx.com/products/nginx-ingress-controller/) | [Project Github Link](https://github.com/kubernetes/ingress-nginx) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/dns-infra/ingress-nginx) | [Artifact Link](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to Ingress-nginx can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/jaeger.md
+++ b/docs/jaeger.md
@@ -1,0 +1,7 @@
+# jaeger
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [jaeger](https://www.jaegertracing.io/) | [Project Github Link](https://github.com/jaegertracing/jaeger) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/observability/jaeger) | [Artifact Link](https://artifacthub.io/packages/helm/jaegertracing/jaeger) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to jaeger can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/keycloak.md
+++ b/docs/keycloak.md
@@ -1,0 +1,7 @@
+# keycloak
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [keycloak](https://www.keycloak.org/) | [Project Github Link](https://github.com/keycloak/keycloak) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes) | [Artifact Link](https://artifacthub.io/packages/helm/codecentric/keycloak) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to keycloak can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/kube-prometheus-stack.md
+++ b/docs/kube-prometheus-stack.md
@@ -1,0 +1,7 @@
+# kube-prometheus-stack
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [kube-prometheus-stack](https://github.com/prometheus-operator/kube-prometheus) | [Project Github Link](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/observability/kube-prometheus-stack) | [Artifact Link](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to kube-prometheus-stack can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/loki-stack.md
+++ b/docs/loki-stack.md
@@ -1,0 +1,7 @@
+# loki-stack
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [loki-stack](https://grafana.com/oss/loki/) | [Project Github Link](https://github.com/grafana/loki) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/observability/loki-stack) | [Artifact Link](https://artifacthub.io/packages/helm/loki-stack/loki-stack) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to loki-stack can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/oauth2-proxy.md
+++ b/docs/oauth2-proxy.md
@@ -1,0 +1,7 @@
+# oauth2-proxy
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) | [Project Github Link](https://github.com/oauth2-proxy/oauth2-proxy) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes) | [Artifact Link](https://artifacthub.io/packages/helm/oauth2-proxy/oauth2-proxy) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to oauth2-proxy can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/opentelemetry-collector.md
+++ b/docs/opentelemetry-collector.md
@@ -1,0 +1,7 @@
+# opentelemetry-collector
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [opentelemetry-collector](https://opentelemetry.io/) | [Project Github Link](https://github.com/open-telemetry/opentelemetry-collector) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/observability/opentelemetry-collector) | [Artifact Link](https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to opentelemetry-collector can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -1,0 +1,7 @@
+# postgresql
+
+| Website | Project GitHub | Ortelius Github | Artifact Reference | Owners |
+| --- | --- | --- | --- | --- |
+| [postgresql](https://www.postgresql.org/) | [Project Github Link](https://github.com/postgres/postgres) | [Ortelius Github Link](https://github.com/ortelius/ortelius-kubernetes/tree/main/kube-infra/kustomize/datastore/postgresql) | [Artifact Link](http://artifacthub.io/packages/helm/bitnami/postgresql) | [@bradmccoydev](https://github.com/bradmccoydev)  |
+
+All the code that relates to postgresql can be found [here.](https://github.com:ortelius/ortelius-kubernetes/) This consists of the Kubernetes manifest files required to provision the tooling and configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,19 @@ site_name: 'ortelius'
 
 nav:
   - Home: index.md
+  - ArgoCD: argocd.md
+  - cert-manager: cert-manager.md
+  - external-dns: external-dns.md
+  - ingress-nginx: ingress-nginx.md
+  - oauth2-proxy: oauth2-proxy.md
+  - keycloak: keycloak.md
+  - backstage: backstage.md
+  - postgresql: postgresql.md
+  - kube-prometheus-stack: kube-prometheus-stack.md
+  - loki-stack: loki-stack.md
+  - jaeger: jaeger.md
+  - grafana: grafana.md
+  - opentelemetry-collector: opentelemetry-collector.md
 
 plugins:
   - techdocs-core


### PR DESCRIPTION
Add Techdocs page for each of the apps
I have added techdocs for the following apps:
- [argocd](https://argoproj.github.io/cd/)
- [cert-manager](https://certmanager.io/)
- [external-dns](https://https//github.com/kubernetes-sigs/external-dns)
- [ingress-nginx](https://kubernetes.github.io/ingress-nginx)
- [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/)
- [keycloak](https://www.keycloak.org/)
- [backstage](https://backstage.io/)
- [postgresql](https://www.postgresql.org/)
- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
- [loki-stack](https://grafana.com/oss/loki/)
- [jaeger](https://www.jaegertracing.io/)
- [grafana](https://grafana.com/)
- [opentelemetry-collector](https://opentelemetry.io/)

I have also updated the mkdocs.yml too
```
site_name: 'ortelius'

nav:
  - Home: index.md
  - ArgoCD: argocd.md
  - cert-manager: cert-manager.md
  - external-dns: external-dns.md
  - ingress-nginx: ingress-nginx.md
  - oauth2-proxy: oauth2-proxy.md
  - keycloak: keycloak.md
  - backstage: backstage.md
  - postgresql: postgresql.md
  - kube-prometheus-stack: kube-prometheus-stack.md
  - loki-stack: loki-stack.md
  - jaeger: jaeger.md
  - grafana: grafana.md
  - opentelemetry-collector: opentelemetry-collector.md

plugins:
  - techdocs-core

```